### PR TITLE
feat: enable LAN access for frontend and auto-detect backend API address

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -1,7 +1,22 @@
 import { SplitzBackendApi } from "./openapi/apis/SplitzBackendApi";
 import { Configuration } from "./openapi/runtime";
 
-const basePath = "http://localhost:5119";
+// Automatically select backend API address based on frontend access address
+// If frontend accesses via LAN IP, backend uses the same IP
+const getBasePath = () => {
+  const hostname = window.location.hostname;
+
+  // If frontend accesses via localhost or 127.0.0.1, backend also uses localhost
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return "http://localhost:5119";
+  }
+
+  // If frontend accesses via LAN IP (mobile devices), backend uses the same IP
+  // Example: frontend is http://192.168.1.100:5173, backend is http://192.168.1.100:5119
+  return `http://${hostname}:5119`;
+};
+
+const basePath = getBasePath();
 
 const config = new Configuration({
   basePath: basePath,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,11 @@
-import vue from '@vitejs/plugin-vue'
-import process from 'node:process'
-import { fileURLToPath, URL } from 'node:url'
-import { ExternalFluentPlugin, SFCFluentPlugin } from 'unplugin-fluent-vue/vite'
-import { defineConfig } from 'vite'
-import vueDevTools from 'vite-plugin-vue-devtools'
+import vue from "@vitejs/plugin-vue";
+import process from "node:process";
+import { fileURLToPath, URL } from "node:url";
+import { ExternalFluentPlugin, SFCFluentPlugin } from "unplugin-fluent-vue/vite";
+import { defineConfig } from "vite";
+import vueDevTools from "vite-plugin-vue-devtools";
 
-const isStorybookProcess = process.env.npm_lifecycle_event === 'storybook'
+const isStorybookProcess = process.env.npm_lifecycle_event === "storybook";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -16,21 +16,25 @@ export default defineConfig({
     !isStorybookProcess && vueDevTools(),
     // define messages in SFCs
     SFCFluentPlugin({
-      blockType: 'fluent', // default 'fluent' - name of the block in SFCs
+      blockType: "fluent", // default 'fluent' - name of the block in SFCs
       checkSyntax: true // default true - whether to check syntax of the messages
     }),
     // define messages in external ftl files
     ExternalFluentPlugin({
-      locales: ['en', 'zh-cn'], // required - list of locales
+      locales: ["en", "zh-cn"], // required - list of locales
       checkSyntax: true, // default true - whether to check syntax of the messages
 
-      baseDir: fileURLToPath(new URL('src', import.meta.url)), // base directory for Vue files
-      ftlDir: fileURLToPath(new URL('src/locales', import.meta.url)) // directory with ftl files
+      baseDir: fileURLToPath(new URL("src", import.meta.url)), // base directory for Vue files
+      ftlDir: fileURLToPath(new URL("src/locales", import.meta.url)) // directory with ftl files
     })
   ],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('src', import.meta.url))
+      "@": fileURLToPath(new URL("src", import.meta.url))
     }
+  },
+  server: {
+    host: "0.0.0.0", // Allow access from local network
+    port: 5173
   }
-})
+});


### PR DESCRIPTION
- Configure Vite dev server to listen on 0.0.0.0 for LAN access
- Auto-detect backend API address based on frontend access address
- Use localhost for backend when frontend accessed via localhost
- Use same LAN IP for backend when frontend accessed via LAN IP (from devices other than the server running device)