### PR TITLE
refactor: add useQueryCache in multiple components and streamline user data access

### DIFF
--- a/src/pages/CreateGroupPage/CreateGroupPage.vue
+++ b/src/pages/CreateGroupPage/CreateGroupPage.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { PhCopy } from "@phosphor-icons/vue";
-import { useQuery } from "@pinia/colada";
+import { useQueryCache } from "@pinia/colada";
 import { useFluent } from "fluent-vue";
 import { computed, ref } from "vue";
 import { toast } from "vue-sonner";
 
-import { AccountApi, GroupApi, type GroupDto, type GroupJoinLinkDto } from "@/backend";
+import { GroupApi, type GroupDto, type GroupJoinLinkDto } from "@/backend";
 import config from "@/backend/config";
 import HeaderMobileSecondary from "@/components/Header/Mobile/Secondary/HeaderMobileSecondary.vue";
 import Layout from "@/components/Layout/Layout.vue";
@@ -13,15 +13,15 @@ import SButton from "@/components/SButton/SButton.vue";
 import SIconButton from "@/components/SButton/SIconButton.vue";
 import TextInput from "@/components/TextInput/TextInput.vue";
 import { useRouterHistoryStore } from "@/stores/routing-history";
+import { useUserStore } from "@/stores/user";
 
 const routerHistoryStore = useRouterHistoryStore();
 
 const { $t } = useFluent();
+const queryCache = useQueryCache();
 
-const accountApi = new AccountApi(config);
 const groupApi = new GroupApi(config);
-
-const { state: userInfo } = useQuery({ key: ["getUserInfo"], query: () => accountApi.getUserInfo() });
+const userStore = useUserStore();
 
 const groupName = ref("");
 const loading = ref(false);
@@ -39,11 +39,11 @@ const joinUrl = computed(() => {
 });
 
 const canSubmit = computed(() => {
-  return !!userInfo.value.data && groupName.value.trim().length > 0 && !loading.value;
+  return !!userStore.user && groupName.value.trim().length > 0 && !loading.value;
 });
 
 async function submit() {
-  if (!userInfo.value.data) {
+  if (!userStore.user) {
     toast.error($t("create-group-error-user-not-ready"));
     return;
   }
@@ -55,7 +55,7 @@ async function submit() {
   try {
     const group = await groupApi.createGroup({
       groupInputDto: {
-        membersId: [userInfo.value.data.id],
+        membersId: [userStore.user.id],
         name,
       },
     });
@@ -65,6 +65,7 @@ async function submit() {
     const link = await groupApi.createGroupJoinLink({ groupId: group.groupId });
     joinLink.value = link;
 
+    queryCache.invalidateQueries({ key: ["getGroups"] });
     toast.success($t("create-group-success"));
   } catch (error) {
     console.error(error);

--- a/src/pages/JoinGroupPage/JoinGroupPage.vue
+++ b/src/pages/JoinGroupPage/JoinGroupPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useQuery } from "@pinia/colada";
+import { useQuery, useQueryCache } from "@pinia/colada";
 import { useFluent } from "fluent-vue";
 import { computed, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
@@ -12,6 +12,7 @@ import Layout from "@/components/Layout/Layout.vue";
 import SButton from "@/components/SButton/SButton.vue";
 
 const { $t } = useFluent();
+const queryCache = useQueryCache();
 const route = useRoute();
 const router = useRouter();
 
@@ -31,6 +32,7 @@ async function join() {
   joining.value = true;
   try {
     await groupApi.joinGroupByLink({ joinLinkId: joinLinkId.value });
+    queryCache.invalidateQueries({ key: ["getGroups"] });
     toast.success($t("join-group-success"));
     await router.push("/");
   } catch (error) {

--- a/src/pages/NewExpensePage/ReviewAndCompletePage/TransactionInfoCard.vue
+++ b/src/pages/NewExpensePage/ReviewAndCompletePage/TransactionInfoCard.vue
@@ -1,25 +1,22 @@
 <script setup lang="ts">
 import { PhFiles } from "@phosphor-icons/vue";
-import { useQuery } from "@pinia/colada";
 import { useFluent } from "fluent-vue";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
-import { AccountApi } from "@/backend";
-import config from "@/backend/config";
 import { useTransactionStore } from "@/stores/transaction";
+import { useUserStore } from "@/stores/user";
 
 const { $t } = useFluent();
 const transactionStore = useTransactionStore();
 const { transaction } = storeToRefs(transactionStore);
 
-const accountApi = new AccountApi(config);
-const { data: userInfo } = useQuery({ key: ["getUserInfo"], query: () => accountApi.getUserInfo() });
+const userStore = useUserStore();
 
 const amountOwed = computed(() => {
-  if (transactionStore.paidBy && userInfo.value?.id && transaction.value.amount) {
-    let owed = transactionStore.finalSplitAmount[userInfo.value.id] ?? 0;
-    if (transactionStore.paidBy === userInfo.value.id) {
+  if (transactionStore.paidBy && userStore.user?.id && transaction.value.amount) {
+    let owed = transactionStore.finalSplitAmount[userStore.user.id] ?? 0;
+    if (transactionStore.paidBy === userStore.user.id) {
       owed = owed - transaction.value.amount;
     }
     return owed;

--- a/src/pages/NewExpensePage/SelectPeoplePage/SelectPeoplePage.vue
+++ b/src/pages/NewExpensePage/SelectPeoplePage/SelectPeoplePage.vue
@@ -4,12 +4,13 @@ import { useFluent } from "fluent-vue";
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 
-import { GroupApi, AccountApi } from "@/backend";
+import { GroupApi } from "@/backend";
 import config from "@/backend/config";
 import HeaderMobileSecondary from "@/components/Header/Mobile/Secondary/HeaderMobileSecondary.vue";
 import Layout from "@/components/Layout/Layout.vue";
 import SButton from "@/components/SButton/SButton.vue";
 import { useTransactionStore } from "@/stores/transaction";
+import { useUserStore } from "@/stores/user";
 
 import FrequentSelectionList from "./FrequentSelectionList.vue";
 import SearchBar from "./SearchBar.vue";
@@ -30,10 +31,9 @@ const searchKeyword = ref<string>("");
 
 // fetch groups and user info
 const groupApi = new GroupApi(config);
-const accountApi = new AccountApi(config);
+const userStore = useUserStore();
 
 const { state: groups } = useQuery({ key: ["getGroups"], query: () => groupApi.getGroups() });
-const { state: userInfo } = useQuery({ key: ["getUserInfo"], query: () => accountApi.getUserInfo() });
 
 // map groups with members and replace userName with remark if exists
 const mappedGroups = computed(() => {
@@ -41,7 +41,7 @@ const mappedGroups = computed(() => {
   const groupsValue = structuredClone(groups.value.data);
   // create a map for user friends
   const friendsMap = new Map<string, string>();
-  userInfo.value.data?.friends?.forEach((friend) => {
+  userStore.user?.friends?.forEach((friend) => {
     friendsMap.set(friend.friendUser.id, friend.remark ?? friend.friendUser.userName);
   });
   // replace member userName with remark if exists
@@ -65,8 +65,8 @@ const sortedGroupsGroupOnly = computed(() => {
   return sortedGroups.value.filter((group) => group.members.length > 2);
 });
 const sortedFriends = computed(() => {
-  if (!userInfo.value.data?.friends) return [];
-  let friendsValue = [...userInfo.value.data.friends];
+  if (!userStore.user?.friends) return [];
+  let friendsValue = [...userStore.user.friends];
   if (searchKeyword.value)
     friendsValue = friendsValue.filter(
       (friend) =>
@@ -123,7 +123,7 @@ const onItemSelected = (itemId: string) => {
     return router.push({ name: "newExpenseSelectSplitMethod" });
   }
 
-  const friend = userInfo.value.data?.friends?.find((f) => f.friendUser.id === itemId);
+  const friend = userStore.user?.friends?.find((f) => f.friendUser.id === itemId);
   if (friend) {
     // if the item is a friend, we just add / remove the friend to the selected items
     if (selectedItemsId.value.includes(itemId)) {
@@ -137,7 +137,7 @@ const onItemSelected = (itemId: string) => {
 // mapping selected users for the search bar
 const selectedUsers = computed(() => {
   return (
-    userInfo.value.data?.friends
+    userStore.user?.friends
       ?.filter((friend) => selectedItemsId.value.includes(friend.friendUser.id))
       .map((friend) => ({
         id: friend.friendUser.id,
@@ -150,7 +150,7 @@ const selectedUsers = computed(() => {
 // onSelectedUsersSubmitted function to handle the submission of selected users
 const onSelectedUsersSubmittedLoading = ref(false);
 const onSelectedUsersSubmitted = async () => {
-  if (!userInfo.value.data) return;
+  if (!userStore.user) return;
   if (selectedItemsId.value.length === 0) return;
   onSelectedUsersSubmittedLoading.value = true;
   try {

--- a/src/pages/NewExpensePage/SelectSplitMethodPage/PaidByButton.vue
+++ b/src/pages/NewExpensePage/SelectSplitMethodPage/PaidByButton.vue
@@ -1,29 +1,26 @@
 <script setup lang="ts">
 import { PhCaretDown } from "@phosphor-icons/vue";
-import { useQuery } from "@pinia/colada";
 import { useFluent } from "fluent-vue";
 import { computed, ref, watch } from "vue";
 
-import { AccountApi } from "@/backend";
-import config from "@/backend/config";
 import Avatar from "@/components/Avatar/Avatar.vue";
 import SButton from "@/components/SButton/SButton.vue";
 import Sheet from "@/components/Sheet/Sheet.vue";
 import { useTransactionStore } from "@/stores/transaction";
+import { useUserStore } from "@/stores/user";
 
 // i18n
 const { $t } = useFluent();
 
 const transactionStore = useTransactionStore();
-const accountApi = new AccountApi(config);
-const { state: userInfo } = useQuery({ key: ["getUserInfo"], query: () => accountApi.getUserInfo() });
+const userStore = useUserStore();
 
 // Ensure that the paidBy is set to the current user if not already set
 watch(
-  userInfo,
+  () => userStore.user,
   (newValue) => {
-    if (newValue.data && !transactionStore.paidBy) {
-      transactionStore.paidBy = newValue.data.id;
+    if (newValue && !transactionStore.paidBy) {
+      transactionStore.paidBy = newValue.id;
     }
   },
   { immediate: true }
@@ -40,11 +37,11 @@ watch(
 const paidByUsername = computed(() => {
   if (!transactionStore.paidBy) return "...";
 
-  if (transactionStore.paidBy === userInfo.value.data?.id) {
+  if (transactionStore.paidBy === userStore.user?.id) {
     return $t("new-expense-pronoun-you");
   }
 
-  const friend = userInfo.value.data?.friends?.find((friend) => friend.friendUser.id === transactionStore.paidBy);
+  const friend = userStore.user?.friends?.find((friend) => friend.friendUser.id === transactionStore.paidBy);
   if (friend) {
     return friend.remark ?? friend.friendUser.userName;
   }

--- a/src/pages/TransactionDetailPage/TransactionDetailPage.vue
+++ b/src/pages/TransactionDetailPage/TransactionDetailPage.vue
@@ -104,6 +104,8 @@ async function handleDelete() {
     isDeleting.value = true;
     await transactionApi.deleteTransaction({ id: transactionId.value });
     queryCache.invalidateQueries({ key: ["getGroupTransactions", groupId.value] });
+    queryCache.invalidateQueries({ key: ["getGroup", groupId.value] });
+    queryCache.invalidateQueries({ key: ["getGroups"] });
     void router.replace({ name: "groupDetail", params: { groupId: groupId.value } });
   } catch (error) {
     console.error("Error deleting transaction:", error);

--- a/src/stores/invoice.ts
+++ b/src/stores/invoice.ts
@@ -1,3 +1,4 @@
+import { useQueryCache } from "@pinia/colada";
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
@@ -5,6 +6,8 @@ import { InvoiceApi, type InvoiceDto, type InvoiceInputDto, type TransactionDto 
 import config from "@/backend/config";
 
 export const useInvoiceStore = defineStore("invoice", () => {
+  const queryCache = useQueryCache();
+
   const invoiceId = ref<string | null>(null);
   const invoice = ref<InvoiceInputDto>({
     currency: "USD",
@@ -56,22 +59,28 @@ export const useInvoiceStore = defineStore("invoice", () => {
     const api = new InvoiceApi(config);
 
     // If the invoice doesn't have an ID, it means it's not created yet, so we create it. Otherwise, we update the existing invoice.
+    let result: InvoiceDto;
     if (!invoiceId.value) {
-      const result = await api.createInvoice({
+      result = await api.createInvoice({
         invoiceInputDto: invoice.value,
       });
       createdInvoice.value = result;
       invoiceId.value = result.invoiceId;
-      return result;
     } else {
       await api.updateInvoice({
         id: invoiceId.value,
         invoiceInputDto: invoice.value,
       });
-      const result = await api.getInvoice({ id: invoiceId.value });
+      result = await api.getInvoice({ id: invoiceId.value });
       createdInvoice.value = result;
-      return result;
     }
+
+    // Invalidate relevant queries to ensure UI reflects the latest data
+    const groupId = invoice.value.groupId;
+    if (groupId) {
+      await queryCache.invalidateQueries({ key: ["getGroupInvoices", groupId] });
+    }
+    return result;
   }
 
   function reset() {

--- a/src/stores/transaction.ts
+++ b/src/stores/transaction.ts
@@ -1,3 +1,4 @@
+import { useQueryCache } from "@pinia/colada";
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
@@ -23,6 +24,8 @@ const round = (value: number) => {
 };
 
 export const useTransactionStore = defineStore("transaction", () => {
+  const queryCache = useQueryCache();
+
   const transaction = ref<Omit<TransactionDraftInputDto, "amount"> & { amount?: number }>({
     amount: 0,
     currency: "USD",
@@ -284,6 +287,7 @@ export const useTransactionStore = defineStore("transaction", () => {
       transactionTime: transaction.value.transactionTime ?? new Date(),
     };
 
+    let result: TransactionDto;
     // If transactionId exists, update the transaction, otherwise create a new one
     if (transactionId.value) {
       await api.updateTransaction({
@@ -291,15 +295,23 @@ export const useTransactionStore = defineStore("transaction", () => {
         transactionInputDto: transactionInput,
       });
       // For update, we need to get the updated transaction since updateTransaction returns void
-      return await api.getTransaction({ id: transactionId.value });
+      result = await api.getTransaction({ id: transactionId.value });
     } else {
       // Create new transaction
-      const result = await api.addTransaction({
+      result = await api.addTransaction({
         transactionInputDto: transactionInput,
       });
       transactionId.value = result.transactionId;
-      return result;
     }
+
+    // Invalidate relevant queries to ensure UI updates with the latest data
+    if (groupId) {
+      await queryCache.invalidateQueries({ key: ["getGroupTransactions", groupId] });
+      await queryCache.invalidateQueries({ key: ["getGroup", groupId] });
+    }
+    await queryCache.invalidateQueries({ key: ["getGroups"] });
+
+    return result;
   };
 
   const uploadTransactionReceipt = async (file: Blob): Promise<void> => {


### PR DESCRIPTION
This pull request refactors user data fetching across several pages and stores to use the new `userStore` instead of direct API queries, improving consistency and reducing redundant network calls. Additionally, it introduces systematic cache invalidation using `queryCache.invalidateQueries` after group, transaction, and invoice mutations to ensure the UI reflects the latest data. These changes enhance data flow, maintain UI consistency after mutations, and simplify the codebase.

**User Data Handling Refactor:**
* Replaced all direct `getUserInfo` API queries with centralized access through `userStore.user` in components such as `CreateGroupPage.vue`, `SelectPeoplePage.vue`, `ReviewAndCompletePage/TransactionInfoCard.vue`, and `SelectSplitMethodPage/PaidByButton.vue` for improved consistency and reduced duplication. [[1]](diffhunk://#diff-9e5f881464a18a0e3f99864f2c63c1630ae01fac5c10a54b6d0281709f092613L3-R24) [[2]](diffhunk://#diff-1b028b502fd2723c62982a35bd39d9fb70b183329eb6417a2972f41f3112e940L7-R13) [[3]](diffhunk://#diff-878a93f2f1c372a40a6082cf996a6f58d85e2145ca795526423b16f27651cf4cL3-R19) [[4]](diffhunk://#diff-1ecb9245ee60994c38755093a3b57eda14bf41e3550272723ddc461e529724c2L3-R23)

**Cache Invalidation After Mutations:**
* Added `queryCache.invalidateQueries` calls after group creation and joining (`CreateGroupPage.vue`, `JoinGroupPage.vue`), group deletion and transaction deletion (`TransactionDetailPage.vue`), and after invoice and transaction creation or update (`invoice.ts`, `transaction.ts`) to ensure the UI displays up-to-date information. [[1]](diffhunk://#diff-9e5f881464a18a0e3f99864f2c63c1630ae01fac5c10a54b6d0281709f092613R68) [[2]](diffhunk://#diff-676200243455f1538c875310570f693f89eb453cdc0d21f0c2fe3798d6893d92R35) [[3]](diffhunk://#diff-c3a4e32df34e950da717d2ec619db51c4ffc4e781d8e3a717a33359776887364R107-R108) [[4]](diffhunk://#diff-e10563dd68fc72c8fb612b71d204dfad90b99d8032ed7e080677705a7d51bcb2R1-R10) [[5]](diffhunk://#diff-e10563dd68fc72c8fb612b71d204dfad90b99d8032ed7e080677705a7d51bcb2R62-R83) [[6]](diffhunk://#diff-9daeb53e09cbdc86a54c3e9bb64aba8956004cbbee8fd3bcbc9bf431bbc93f77R1) [[7]](diffhunk://#diff-9daeb53e09cbdc86a54c3e9bb64aba8956004cbbee8fd3bcbc9bf431bbc93f77R290-R314)

**Code Simplification and Cleanup:**
* Removed unused imports and redundant API instantiations related to user information fetching in several files, streamlining the codebase. [[1]](diffhunk://#diff-1b028b502fd2723c62982a35bd39d9fb70b183329eb6417a2972f41f3112e940L7-R13) [[2]](diffhunk://#diff-1ecb9245ee60994c38755093a3b57eda14bf41e3550272723ddc461e529724c2L3-R23) [[3]](diffhunk://#diff-878a93f2f1c372a40a6082cf996a6f58d85e2145ca795526423b16f27651cf4cL3-R19)

**Consistency in State Usage:**
* Updated all references to user and friends data to use `userStore.user` and its properties, ensuring consistent state management throughout the application. [[1]](diffhunk://#diff-1b028b502fd2723c62982a35bd39d9fb70b183329eb6417a2972f41f3112e940L33-R44) [[2]](diffhunk://#diff-1b028b502fd2723c62982a35bd39d9fb70b183329eb6417a2972f41f3112e940L68-R69) [[3]](diffhunk://#diff-1b028b502fd2723c62982a35bd39d9fb70b183329eb6417a2972f41f3112e940L126-R126) [[4]](diffhunk://#diff-1b028b502fd2723c62982a35bd39d9fb70b183329eb6417a2972f41f3112e940L140-R140) [[5]](diffhunk://#diff-1b028b502fd2723c62982a35bd39d9fb70b183329eb6417a2972f41f3112e940L153-R153) [[6]](diffhunk://#diff-1ecb9245ee60994c38755093a3b57eda14bf41e3550272723ddc461e529724c2L43-R44)

**Improved UI Reactivity:**
* Ensured that after any group, transaction, or invoice mutation, the relevant cached queries are invalidated, which triggers updates in UI components relying on those queries. [[1]](diffhunk://#diff-9e5f881464a18a0e3f99864f2c63c1630ae01fac5c10a54b6d0281709f092613R68) [[2]](diffhunk://#diff-676200243455f1538c875310570f693f89eb453cdc0d21f0c2fe3798d6893d92R35) [[3]](diffhunk://#diff-c3a4e32df34e950da717d2ec619db51c4ffc4e781d8e3a717a33359776887364R107-R108) [[4]](diffhunk://#diff-e10563dd68fc72c8fb612b71d204dfad90b99d8032ed7e080677705a7d51bcb2R62-R83) [[5]](diffhunk://#diff-9daeb53e09cbdc86a54c3e9bb64aba8956004cbbee8fd3bcbc9bf431bbc93f77R290-R314)